### PR TITLE
Fix config generation

### DIFF
--- a/reconbf/__main__.py
+++ b/reconbf/__main__.py
@@ -32,7 +32,12 @@ def main():
 
     # are we just writing configuration instead of doing standard run?
     if args.generate_config:
-        _generate_config(args.config_file, args.generate_config)
+        if args.config_file:
+            fobj = open(args.config_file, "w")
+        else:
+            fobj = sys.stdout
+        _generate_config(fobj, args.generate_config)
+        fobj.flush()
         sys.exit()
 
     # are we just explaining a specifc test?
@@ -81,7 +86,7 @@ def main():
         sys.exit(0)
 
 
-def _generate_config(filename, mode):
+def _generate_config(output, mode):
     new_config = {'modules': {}}
     modules_config = new_config['modules']
 
@@ -104,11 +109,10 @@ def _generate_config(filename, mode):
 
     config_content = json.dumps(new_config, separators=(',', ': '),
                                 indent=4, sort_keys=True)
-    if filename:
-        with open(filename, "w") as f:
-            f.write(config_content)
-    else:
-        print(config_content)
+    if str is bytes:
+        config_content = config_content.decode('utf-8')
+
+    output.write(config_content)
 
 
 def _check_root():

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -1,0 +1,16 @@
+from reconbf import __main__
+
+import io
+import unittest
+
+
+class ConfigGeneration(unittest.TestCase):
+    def test_default(self):
+        output = io.StringIO()
+        __main__._generate_config(output, "default")
+        self.assertTrue(len(output.getvalue()) > 0)
+
+    def test_inline(self):
+        output = io.StringIO()
+        __main__._generate_config(output, "inline")
+        self.assertTrue(len(output.getvalue()) > 0)

--- a/tests/test_sec.py
+++ b/tests/test_sec.py
@@ -1,0 +1,48 @@
+from reconbf.modules import test_sec
+from reconbf.lib.result import Result
+from reconbf.lib import utils
+
+import unittest
+from mock import patch
+
+
+class SysctlValues(unittest.TestCase):
+    def test_match(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="bar"):
+            res = test_sec.test_sysctl_values({"x": ("match", "bar")})
+        self.assertEqual(res.result, Result.PASS)
+
+    def test_not_match(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="bar"):
+            res = test_sec.test_sysctl_values({"x": ("match", "xxx")})
+        self.assertEqual(res.result, Result.FAIL)
+
+    def test_one_of(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="bar"):
+            res = test_sec.test_sysctl_values({"x": ("one_of", ["bar", "x"])})
+        self.assertEqual(res.result, Result.PASS)
+
+    def test_not_one_of(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="bar"):
+            res = test_sec.test_sysctl_values({"x": ("one_of", ["x"])})
+        self.assertEqual(res.result, Result.FAIL)
+
+    def test_none_of(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="bar"):
+            res = test_sec.test_sysctl_values({"x": ("none_of", ["x"])})
+        self.assertEqual(res.result, Result.PASS)
+
+    def test_not_none_of(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="bar"):
+            res = test_sec.test_sysctl_values({"x": ("none_of", ["bar", "x"])})
+        self.assertEqual(res.result, Result.FAIL)
+
+    def test_at_least(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="10"):
+            res = test_sec.test_sysctl_values({"x": ("at_least", "5")})
+        self.assertEqual(res.result, Result.PASS)
+
+    def test_not_at_least(self):
+        with patch.object(utils, 'get_sysctl_value', return_value="0"):
+            res = test_sec.test_sysctl_values({"x": ("at_least", "5")})
+        self.assertEqual(res.result, Result.FAIL)


### PR DESCRIPTION
Switch sysctl config back to plain dicts/tuples. Objects don't serialise
into JSON. Add sysctl and config tests so it doesn't happen again.