### PR TITLE
Make recon BSD compatible

### DIFF
--- a/reconbf/lib/result.py
+++ b/reconbf/lib/result.py
@@ -645,7 +645,7 @@ def _get_term_colors():
 def _get_term_width():
     # try to get the width from stty (option columns)
     try:
-        term_settings = subprocess.check_output(['stty', '--all'])
+        term_settings = subprocess.check_output(['stty', '-a'])
 
     except (IOError, subprocess.CalledProcessError):
         # stty is not installed, or failed: assume 80 columns
@@ -654,9 +654,13 @@ def _get_term_width():
     for line in term_settings.splitlines():
         for setting in line.split(b';'):
             try:
-                option, value = setting.strip().split(b' ', 1)
-                if option.strip() == b'columns':
-                    return int(value.strip())
+                part1, part2 = setting.strip().split(b' ', 1)
+                # linux order
+                if part1.strip() == b'columns':
+                    return int(part2.strip())
+                # bsd order
+                elif part2.strip() == b'columns':
+                    return int(part1.strip())
             except ValueError:
                 # unexpected format
                 continue

--- a/reconbf/modules/test_docker.py
+++ b/reconbf/modules/test_docker.py
@@ -16,6 +16,7 @@ from reconbf.lib.logger import logger
 import functools
 import json
 import os
+import platform
 import subprocess
 import reconbf.lib.test_class as test_class
 from reconbf.lib.result import Result, GroupTestResult, TestResult
@@ -330,6 +331,10 @@ def test_storage_driver():
     """)
 def test_docker_daemon():
     logger.debug("Checking auditing on the Docker daemon.")
+
+    if platform.system() != 'Linux':
+        return TestResult(Result.SKIP, "applies to Linux only")
+
     note = "Test is invalid for newer kernels."
 
     kernel = tuple(int(x) for x in os.uname()[2].split('.')[:2])

--- a/reconbf/modules/test_firewall.py
+++ b/reconbf/modules/test_firewall.py
@@ -15,6 +15,7 @@
 from reconbf.lib import test_class
 from reconbf.lib.result import Result
 from reconbf.lib.result import TestResult
+from reconbf.lib import utils
 
 import collections
 import subprocess
@@ -59,6 +60,9 @@ def _get_default_policy(rules):
     option in case of missed rules.
     """)
 def firewall_whitelisting():
+    if not utils.have_command('iptables-save'):
+        return TestResult(Result.SKIP, "iptables not available")
+
     rules = _list_rules()
     if rules is None:
         return TestResult(Result.SKIP, "Cannot retrieve iptables rules")

--- a/reconbf/modules/test_hardware.py
+++ b/reconbf/modules/test_hardware.py
@@ -18,6 +18,7 @@ from reconbf.lib.result import Result
 from reconbf.lib.result import TestResult
 
 import os
+import platform
 
 
 @test_class.explanation(
@@ -34,6 +35,9 @@ import os
     HID, storage, or exploitation device.
     """)
 def usb_authorization():
+    if platform.system() != 'Linux':
+        return TestResult(Result.SKIP, "available only on Linux")
+
     open_hosts = []
     hosts = [dev for dev in os.listdir('/sys/bus/usb/devices') if
              dev.startswith('usb')]

--- a/reconbf/modules/test_mounts.py
+++ b/reconbf/modules/test_mounts.py
@@ -24,7 +24,7 @@ import re
 import subprocess
 
 
-MOUNT_RE = re.compile(b"""
+MOUNT_RE_LINUX = re.compile(b"""
     (.+)  # source
     \s on \s
     (.+)  # destination
@@ -32,6 +32,14 @@ MOUNT_RE = re.compile(b"""
     (.+)  # type
     \s
     \(([^)]*)\)  # options
+    """, re.VERBOSE)
+MOUNT_RE_BSD = re.compile(b"""
+    (.+)  # source
+    \s on \s
+    (.+)  # destination
+    \s \(
+    (.+),  # type
+    ([^)]*)\)  # options
     """, re.VERBOSE)
 
 
@@ -45,7 +53,10 @@ def _get_mounts():
     results = []
 
     for mount in mounts.splitlines():
-        m = MOUNT_RE.match(mount.strip())
+        for RE in (MOUNT_RE_LINUX, MOUNT_RE_BSD):
+            m = RE.match(mount.strip())
+            if m:
+                break
         if not m:
             logger.warning("could not parse mount line '%s'", mount)
             continue

--- a/reconbf/modules/test_mounts.py
+++ b/reconbf/modules/test_mounts.py
@@ -38,7 +38,7 @@ MOUNT_RE_BSD = re.compile(b"""
     \s on \s
     (.+)  # destination
     \s \(
-    (.+),  # type
+    ([^,]*)  # type
     ([^)]*)\)  # options
     """, re.VERBOSE)
 
@@ -64,7 +64,7 @@ def _get_mounts():
             m.group(1),
             m.group(2),
             m.group(3),
-            m.group(4).split(b','),
+            m.group(4).split(b',')[1:],
             ))
 
     return results

--- a/reconbf/modules/test_users.py
+++ b/reconbf/modules/test_users.py
@@ -16,6 +16,7 @@ from reconbf.lib.logger import logger
 import reconbf.lib.test_class as test_class
 from reconbf.lib.result import Result
 from reconbf.lib.result import TestResult
+from reconbf.lib import utils
 
 from collections import defaultdict
 import grp
@@ -92,6 +93,9 @@ def test_accounts_nopassword():
     access to a system.
     """)
 def test_list_sudoers():
+    if not utils.have_command('sudo'):
+        return TestResult(Result.SKIP, "sudo not installed")
+
     # these can be moved to config if there is a good reason somebody would
     # ever want to change them, for now they stay here
     list_sudoer_command = ['sudo', '-U', '$USER', '-l']


### PR DESCRIPTION
Add a few changes which make recon possible to run on BSD-like systems.
This mostly consists of checking if the right utility exists on the system
as well as some changes related to /proc.